### PR TITLE
Disable Drupal page cache for files served with File Aliases paths

### DIFF
--- a/file_aliases.module
+++ b/file_aliases.module
@@ -100,8 +100,13 @@ function file_aliases_load_fid($fid) {
   }
 
   else {
+    drupal_page_is_cacheable(FALSE);
+    /* standard Cache-Control policy copied from bootstrap.inc */
+    $max_age = !isset($_COOKIE[session_name()]) || isset($hook_boot_headers['vary']) ? variable_get('page_cache_maximum_age', 0) : 0;
+    header("Cache-Control: public, max-age={$max_age}" );
+    /* HTTP/1.1 clients ignore the Expires header if a Cache-Control: max-age= directive is specified (see above) */
+    header("Expires: ". gmdate(DATE_RFC1123, REQUEST_TIME + $max_age));
     header("Content-Type: {$result->filemime}");
-    header('Cache-Control: public');
     readfile($result->uri);
   }
 }


### PR DESCRIPTION
This PR: 
- Disable internal Drupal page caching
- Apply cache control headers that can be used by upstream proxies
## Motivation and Context

Without this fix, files served by File Aliases end up in the Drupal page cache, which serves them up with the wrong Content-Type. Also, binary files cached in the DB as blobs is just icky.  
## How Has This Been Tested?

Tested in vagrant build of docreg site. Headers are correct and files don't end up in db cache. 
